### PR TITLE
QosFilter in front of /scan and /scanReply

### DIFF
--- a/src/main/java/fi/solita/clamav/Application.java
+++ b/src/main/java/fi/solita/clamav/Application.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import javax.servlet.MultipartConfigElement;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.eclipse.jetty.servlets.QoSFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -26,6 +28,8 @@ import org.springframework.context.annotation.Configuration;
  */
 public class Application {
 
+  private Log log = LogFactory.getLog(Application.class);
+
   @Value("${clamd.maxfilesize}")
   private String maxfilesize;
 
@@ -43,6 +47,8 @@ public class Application {
 
   @Bean
   MultipartConfigElement multipartConfigElement() {
+    log.info(String.format("Configuring multipart support, maxFileSize=%s, maxRequestSize=%s",
+            maxfilesize, maxrequestsize));
     MultipartConfigFactory factory = new MultipartConfigFactory();
     factory.setMaxFileSize(maxfilesize);
     factory.setMaxRequestSize(maxrequestsize);
@@ -52,6 +58,8 @@ public class Application {
   @Bean
   @ConditionalOnExpression("${clamd.qos.maxrequests} > 0")
   FilterRegistrationBean qosFitlerRegistrationBean() {
+    log.info(String.format("Configuring QoSFilter, maxRequests=%d, waitMs=%d, suspendMs=%d",
+            maxrequests, waitMs, suspendMs));
     FilterRegistrationBean registration = new FilterRegistrationBean();
     registration.setFilter(new QoSFilter());
     registration.addInitParameter("maxRequests", Integer.toString(maxrequests));

--- a/src/main/java/fi/solita/clamav/Application.java
+++ b/src/main/java/fi/solita/clamav/Application.java
@@ -5,10 +5,14 @@ import java.util.Map;
 
 import javax.servlet.MultipartConfigElement;
 
+import org.eclipse.jetty.servlets.QoSFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.embedded.MultipartConfigFactory;
+import org.springframework.boot.web.filter.OrderedHiddenHttpMethodFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -28,12 +32,34 @@ public class Application {
   @Value("${clamd.maxrequestsize}")
   private String maxrequestsize;
 
+  @Value("${clamd.qos.maxrequests}")
+  private int maxrequests;
+
+  @Value("${clamd.qos.waitms}")
+  private int waitMs;
+
+  @Value("${clamd.qos.suspendms}")
+  private int suspendMs;
+
   @Bean
   MultipartConfigElement multipartConfigElement() {
     MultipartConfigFactory factory = new MultipartConfigFactory();
     factory.setMaxFileSize(maxfilesize);
     factory.setMaxRequestSize(maxrequestsize);
     return factory.createMultipartConfig();
+  }
+
+  @Bean
+  @ConditionalOnExpression("${clamd.qos.maxrequests} > 0")
+  FilterRegistrationBean qosFitlerRegistrationBean() {
+    FilterRegistrationBean registration = new FilterRegistrationBean();
+    registration.setFilter(new QoSFilter());
+    registration.addInitParameter("maxRequests", Integer.toString(maxrequests));
+    registration.addInitParameter("waitMs", Integer.toString(waitMs));
+    registration.addInitParameter("suspendMs", Integer.toString(suspendMs));
+    registration.addUrlPatterns("/scan", "/scanReply");
+    registration.setOrder(OrderedHiddenHttpMethodFilter.DEFAULT_ORDER - 1);
+    return registration;
   }
 
   public static void main(String[] args) {
@@ -44,6 +70,9 @@ public class Application {
     defaults.put("clamd.timeout", 500);
     defaults.put("clamd.maxfilesize", "20000KB");
     defaults.put("clamd.maxrequestsize", "20000KB");
+    defaults.put("clamd.qos.maxrequests", -1);
+    defaults.put("clamd.qos.waitms", 50);
+    defaults.put("clamd.qos.suspendms", -1);
     app.setDefaultProperties(defaults);
     app.run(args);
   }


### PR DESCRIPTION
Jetty's QosFilter in front of the `/scan` and `/scanReply` endpoints to allow for configurable maximum concurrency.