### PR TITLE
Fix MAXSIZE param

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ set -m
 
 host=${CLAMD_HOST:-192.168.50.72}
 port=${CLAMD_PORT:-3310}
-filesize=${MAXSIZE:-10GB} 
+filesize=${MAXSIZE:-10240MB} 
 
 echo "using clamd server: $host:$port"
 


### PR DESCRIPTION
As described in https://github.com/solita/clamav-rest/commit/6a44c47cccc46b39cbfee62ef846292b5834b478 the`MAXSIZE` value is currently invalid.