### PR TITLE
Add missing jaxb-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>clamav-client</artifactId>
       <version>1.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+    </dependency>
 
     <!-- tag::jetty[] -->
     <dependency>


### PR DESCRIPTION
jaxb-api dependency is needed to be able to build and run the clamav-rest
with Java 11 since it no longer includes javax.xml.bind.* and results in e.g.

java.lang.ClassNotFoundException: javax.xml.bind.ValidationException

This should fix the failing build and also enables people to run the JAR with Java 11.