### PR TITLE
Web Server Graceful Shutdown

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,8 +6,8 @@ port=${CLAMD_PORT:-3310}
 filesize=${MAXSIZE:-10240MB}
 timeout=${TIMEOUT:-10000}
 loglevel=${LOGLEVEL:-info}
-
+timeout_shutdown=${TIMEOUT_SHUTDOWN:-30}
 echo "using clamd server: $host:$port"
 echo "loglevel: $loglevel"
 
-exec java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout --$loglevel --server.shutdown=graceful --spring.lifecycle.timeout-per-shutdown-phase=60s
+exec java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout --$loglevel --spring.lifecycle.timeout-per-shutdown-phase=$timeout_shutdown --server.shutdown=graceful

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,4 +10,4 @@ loglevel=${LOGLEVEL:-debug}
 echo "using clamd server: $host:$port"
 echo "loglevel: $loglevel"
 
-java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout --$loglevel --server.shutdown=graceful --spring.lifecycle.timeout-per-shutdown-phase=60s
+exec java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout --$loglevel --server.shutdown=graceful --spring.lifecycle.timeout-per-shutdown-phase=60s

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,8 @@ filesize=${MAXSIZE:-10240MB}
 timeout=${TIMEOUT:-10000}
 loglevel=${LOGLEVEL:-info}
 timeout_shutdown=${TIMEOUT_SHUTDOWN:-30}
+
 echo "using clamd server: $host:$port"
 echo "loglevel: $loglevel"
 
-exec java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout --$loglevel --spring.lifecycle.timeout-per-shutdown-phase=$timeout_shutdown --server.shutdown=graceful
+exec java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host="$host" --clamd.port="$port" --clamd.maxfilesize="$filesize" --clamd.maxrequestsize="$filesize" --clamd.timeout="$timeout" --"$loglevel" --spring.lifecycle.timeout-per-shutdown-phase="$timeout_shutdown" --server.shutdown=graceful

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -m
 
-host=${CLAMD_HOST:-192.168.50.72}
+host=${CLAMD_HOST:-127.0.0.1}
 port=${CLAMD_PORT:-3310}
 filesize=${MAXSIZE:-10240MB}
 timeout=${TIMEOUT:-10000}
+loglevel=${LOGLEVEL:-debug}
 
 echo "using clamd server: $host:$port"
+echo "loglevel: $loglevel"
 
-# start in background
-#java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port
-java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout
+java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout --$loglevel --server.shutdown=graceful --spring.lifecycle.timeout-per-shutdown-phase=60s

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@ host=${CLAMD_HOST:-127.0.0.1}
 port=${CLAMD_PORT:-3310}
 filesize=${MAXSIZE:-10240MB}
 timeout=${TIMEOUT:-10000}
-loglevel=${LOGLEVEL:-debug}
+loglevel=${LOGLEVEL:-info}
 
 echo "using clamd server: $host:$port"
 echo "loglevel: $loglevel"


### PR DESCRIPTION
The purpose of this PR is to enable a graceful shutdown for the application and to introduce additional log levels.


You can find more information on this topic at the following link: [Spring Boot Web Server Shutdown](https://www.baeldung.com/spring-boot-web-server-shutdown)

Also modify the script to use [exec](https://hynek.me/articles/docker-signals/) for running the Java application. This approach is particularly useful when utilising Docker/Kubernetes, as it enables signal reception at PID1.

```
2023-05-17 23:05:00.507 DEBUG 1 --- [ionShutdownHook] o.s.b.a.ApplicationAvailabilityBean      : Application availability state ReadinessState changed from ACCEPTING_TRAFFIC to REFUSING_TRAFFIC
2023-05-17 23:05:00.513 DEBUG 1 --- [ionShutdownHook] ConfigServletWebServerApplicationContext : Closing org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@3567135c, started on Wed May 17 23:03:56 UTC 2023
2023-05-17 23:05:00.523  INFO 1 --- [ionShutdownHook] o.s.b.web.embedded.jetty.JettyWebServer  : Commencing graceful shutdown. Waiting for active requests to complete
2023-05-17 23:05:00.527  INFO 1 --- [ jetty-shutdown] o.s.b.web.embedded.jetty.JettyWebServer  : Graceful shutdown complete
2023-05-17 23:05:00.539  INFO 1 --- [ionShutdownHook] o.e.jetty.server.AbstractConnector       : Stopped ServerConnector@38364841{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2023-05-17 23:05:00.540  INFO 1 --- [ionShutdownHook] org.eclipse.jetty.server.session         : node0 Stopped scavenging
2023-05-17 23:05:00.541  INFO 1 --- [ionShutdownHook] o.e.j.s.h.ContextHandler.application     : Destroying Spring FrameworkServlet 'dispatcherServlet'
2023-05-17 23:05:00.543  INFO 1 --- [ionShutdownHook] o.e.jetty.server.handler.ContextHandler  : Stopped o.s.b.w.e.j.JettyEmbeddedWebAppContext@37e547da{application,/,[file:///tmp/jetty-docbase.8080.7305229179307511171/],STOPPED}
```